### PR TITLE
Use stable bookworm-slim version and install prebuilt debian package instead of build from sources.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,33 @@
-FROM alpine:latest
+FROM debian:buster-slim
 
-RUN addgroup webdriver && adduser -h /home/webdriver -s /bin/sh -G webdriver -D webdriver
+RUN useradd -u 1000 -m -U webdriver
 
 WORKDIR /home/webdriver
 
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+COPY chromium-installer /home/webdriver/chromium-installer
 
-RUN apk update && apk add chromium-chromedriver chromium
+ARG CHROMIUM_REVISION
+ENV CHROMIUM_REVISION=${CHROMIUM_REVISION}
 
-RUN ln -s /usr/lib/chromium/chromium-launcher.sh /usr/local/bin/chrome
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get dist-upgrade -y \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+    ca-certificates \
+    curl \
+    chromium-driver chromium \
+  && apt-get autoremove --purge -y \
+      unzip \
+      gnupg \
+  && apt-get clean \
+  && rm -rf \
+    /usr/share/doc/* \
+    /var/cache/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
+    /home/webdriver/*.zip
+
+RUN ln -s /usr/bin/chromium /usr/local/bin/chrome
 
 USER webdriver
 


### PR DESCRIPTION
Alphine build is unstable for a long usage (more than 1 hour).

- Suggest using debian:bullseye-slim as it supports ARM/Intel architectures and more OOTB.  [1]
- We cannot use any more old installer scripts because chrome is not building the ARM version of chromedriver. [2]  But we do not use this script in alphine container already.
- The debian package registry supports Intel/ARM architecture and more OOTB. [3]

So it contains now the stable 103 version of chromedriver that can work on Intel/ARM architectures.

Links:
1) Supported architectures can be checked here: https://hub.docker.com/layers/debian/library/debian/buster-slim/images/sha256-dfa8be0c158e556532b023717650ee2ab52ed2b1b792a5810db138708101548a?context=explore
2) The the moment, the ARM latest revision can be retrieved https://www.googleapis.com/download/storage/v1/b/chromium-browser-snapshots/o/Arm%2FLAST_CHANGE?alt=media and it was a long time ago https://commondatastorage.googleapis.com/chromium-browser-snapshots/index.html?prefix=Arm/103408/
3) For architecture list see section "Download chromedriver" https://packages.debian.org/bullseye/chromium-driver

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
