### PR TITLE
Use stable debian:bullseye-slim prebuilt debian packages.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,28 @@
-FROM alpine:latest
+FROM debian:bullseye-slim
 
-RUN addgroup webdriver && adduser -h /home/webdriver -s /bin/sh -G webdriver -D webdriver
+RUN useradd -u 1000 -m -U webdriver
 
 WORKDIR /home/webdriver
 
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/main" >> /etc/apk/repositories
-RUN echo "https://dl-cdn.alpinelinux.org/alpine/edge/community" >> /etc/apk/repositories
+RUN export DEBIAN_FRONTEND=noninteractive \
+  && apt-get update \
+  && apt-get dist-upgrade -y \
+  && apt-get install --no-install-recommends --no-install-suggests -y \
+    ca-certificates \
+    curl \
+    chromium-driver chromium \
+  && apt-get autoremove --purge -y \
+      unzip \
+      gnupg \
+  && apt-get clean \
+  && rm -rf \
+    /usr/share/doc/* \
+    /var/cache/* \
+    /var/lib/apt/lists/* \
+    /var/tmp/* \
+    /home/webdriver/*.zip
 
-RUN apk update && apk add chromium-chromedriver chromium
-
-RUN ln -s /usr/lib/chromium/chromium-launcher.sh /usr/local/bin/chrome
+RUN ln -s /usr/bin/chromium /usr/local/bin/chrome
 
 USER webdriver
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN export DEBIAN_FRONTEND=noninteractive \
   && apt-get install --no-install-recommends --no-install-suggests -y \
     ca-certificates \
     curl \
+    netcat \
     chromium-driver chromium \
   && apt-get autoremove --purge -y \
       unzip \


### PR DESCRIPTION
Alphine build is unstable for a long usage (more than 1 hour).

- Suggest using debian:bullseye-slim as it supports ARM/Intel architectures and more OOTB.  [1]
- The debian package registry supports Intel/ARM architecture and more OOTB. [2]

So it contains now the stable 103 version of chromedriver that can work on Intel/ARM architectures.

Links:
1) Supported architectures can be checked here: https://hub.docker.com/layers/debian/library/debian/bullseye-slim/images/sha256-139a42fa3bde3e5bad6ae912aaaf2103565558a7a73afe6ce6ceed6e46a6e519?context=explore
2) For architecture list see section "Download chromedriver" https://packages.debian.org/bullseye/chromium-driver

## PR Description

TBD

## Checklist
- [x] I agree with the Code Contribution License Agreement in CONTRIBUTING.md
